### PR TITLE
Add info support

### DIFF
--- a/nimbus-theme.el
+++ b/nimbus-theme.el
@@ -149,7 +149,7 @@
 
    `(popup-tip-face ((t (:background ,nimbus/fg :foreground ,nimbus/bg))))
 
-   `(header-line    ((t (:background ,nimbus/fg :foreground ,nimbus/bg))))
+   `(header-line ((t (:background ,nimbus/darker-gray :foreground ,nimbus/fg))))
 
    ;; which-func mode
    `(which-func
@@ -671,6 +671,22 @@
    `(ediff-odd-diff-B           ((t (:background "#171723"))))
    `(ediff-odd-diff-C           ((t (:background "#171723"))))
    ;;`(ediff-odd-diff-Ancestor      ((t ())))
+
+   ;; info
+   `(Info-quoted
+     ((t (:inherit font-lock-constant-face))))
+   `(info-menu-header
+     ((t (:foreground ,nimbus/light-gray :weight bold :height 1.4))))
+   `(info-menu-star
+     ((t (:foreground ,nimbus/red))))
+   `(info-node
+     ((t (:foreground ,nimbus/light-gray :inherit italic :weight bold))))
+   `(info-title-1
+     ((t (:weight bold :height 1.6))))
+   `(info-title-2
+     ((t (:weight bold :height 1.4))))
+   `(info-title-3
+     ((t (:weight bold :height 1.2))))
 
    ;; man pages
    `(Man-overstrike ((t (:foreground ,nimbus/blue))))


### PR DESCRIPTION
Before:
![info](https://cloud.githubusercontent.com/assets/85483/24082563/116aab7a-0cc8-11e7-837c-8d8882d980a3.png)
After:
![info2](https://cloud.githubusercontent.com/assets/85483/24082593/737835d0-0cc8-11e7-9f7f-b780e1f5f0c6.png)

Header line faces had to be tweaked a bit in order for the links to be readable.