### PR TITLE
Add tooltip face

### DIFF
--- a/nimbus-theme.el
+++ b/nimbus-theme.el
@@ -99,6 +99,7 @@
    `(highlight    ((t (:foreground ,nimbus/bg :background ,nimbus/green))))
    `(region       ((t (:background ,nimbus/green :foreground ,nimbus/black))))
    `(shadow       ((t (:foreground ,nimbus/light-gray))))
+   `(tooltip      ((t (:background ,nimbus/fg :foreground ,nimbus/bg))))
 
    ;; standard font lock
    `(font-lock-builtin-face           ((t (:foreground ,nimbus/light-blue))))


### PR DESCRIPTION
Customization of the built-in `tooltip` face, colors taken from the existing `popup-pos-tip` face.
Before:
![one](https://cloud.githubusercontent.com/assets/85483/24352441/edb09c3a-12e9-11e7-883f-90e1a018b495.png)
After:
![two](https://cloud.githubusercontent.com/assets/85483/24352452/f80f9c4e-12e9-11e7-882d-29ba76f36418.png)

This can be tested by setting `x-gtk-use-system-tooltips` to `nil` so Emacs uses its own tooltip implementation instead of GTK.
