### PR TITLE
Tweak paradox mode-line face

### DIFF
--- a/nimbus-theme.el
+++ b/nimbus-theme.el
@@ -984,6 +984,10 @@
    `(elfeed-search-title-face        ((t (:foreground ,nimbus/fg))))
    `(elfeed-search-unread-count-face ((t (:foreground ,nimbus/fg))))
 
+   ;; paradox
+   `(paradox-mode-line-face
+     ((t (:foreground ,nimbus/blue-bg :bold t))))
+
    ;; message-mode
    `(message-cited-text  ((t (:inherit font-lock-comment-face))))
    `(message-header-cc


### PR DESCRIPTION
Fix for the [Paradox](https://github.com/Malabarba/paradox) mode-line face.

Before:
![one](https://cloud.githubusercontent.com/assets/85483/24444872/47679e52-1468-11e7-8bce-8f937d658bdb.png)

After:
![two](https://cloud.githubusercontent.com/assets/85483/24444883/4dc102fc-1468-11e7-84cd-9064cc45e325.png)

