### PR TITLE
Line number faces should inherit from default

### DIFF
--- a/nimbus-theme.el
+++ b/nimbus-theme.el
@@ -695,8 +695,8 @@
    `(js2-warning ((t (:underline ,orange))))
 
    ;; display-line-numbers
-   `(line-number ((t (:foreground ,line))))
-   `(line-number-current-line ((t (:foreground ,line-current))))
+   `(line-number ((t (:foreground ,line :inherit default))))
+   `(line-number-current-line ((t (:foreground ,line-current :inherit default))))
 
    ;; magit
    `(magit-section-heading ((t (:foreground ,heading))))


### PR DESCRIPTION
Currently, activating display-line-numbers-mode and adjusting the text scale with C-x C-+ and similar commands has no effect on the line numbers.  This commit fixes that.