### PR TITLE
Melpa is now at https://melpa.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Nimbus was originally a fork of [Ample](https://github.com/jordonbiondo/ample-th
 
 ## Installing
 
-Make sure you have set up [MELPA](http://melpa.milkbox.net/#/getting-started) and run:
+Make sure you have set up [MELPA](http://melpa.org/#/getting-started) and run:
 
 ```
 M-x package-install RET nimbus-theme RET


### PR DESCRIPTION
The old link for MELPA doesn't work. This fixes the README file with the new location.