### PR TITLE
Use appropriate quotes in nimbus-theme docstring

### DIFF
--- a/nimbus-theme.el
+++ b/nimbus-theme.el
@@ -1240,7 +1240,7 @@
 
 ;;;###autoload
 (defun nimbus-theme()
-  "Apply 'nimbus-theme'."
+  "Apply ‘nimbus-theme’."
   (interactive)
   (load-theme 'nimbus t))
 


### PR DESCRIPTION
This commit transforms the quotes of the function docstring to those created by electric-quote-mode.

The quoted string now functions as a link to the name of the module and it resolves the warning messages emitted by the byte compiler such as the following:

> Warning (comp): nimbus-theme.el:1244:2: Warning: docstring has wrong
> usage of unescaped single quotes (use \= or different quoting)